### PR TITLE
Prevent processing of blacklisted response formats

### DIFF
--- a/kirby-html-minifier.php
+++ b/kirby-html-minifier.php
@@ -12,6 +12,10 @@ require __DIR__ . DS . 'tiny-html-minifier' . DS . 'tiny-html-minifier.php';
 
 class Minifier extends Response {
 	public function make($response) {
+		if($this->isBlacklisted($response->format())) {
+	            return $response;
+        	}
+		
 		$html = parent::make( $response );
 
 		if(empty($html)) return '';
@@ -31,6 +35,11 @@ class Minifier extends Response {
 			}
 		}
 		return true;
+	}
+	
+	private function isBlacklisted($format, $blacklist = ['js', 'css'])
+	{
+		return in_array($format, $blacklist);
 	}
 }
 


### PR DESCRIPTION
I provide this PR due to some minification issues. If applied, it will prevent `css` and `js` files being processed.

A user of the [kirby-analytics-dashboard](https://github.com/gearsdigital/kirby-analytics-dashboard) plugin reported an issue in the [Getkirby-Forum](https://forum.getkirby.com/t/kirby-analytics-dashboard/9408/21?u=gearsdigital) and told us that there are is an js error, but only if kirby-html-minifier is enabled. After a little debugging I figured out the problem and was able to track down this issue to a very specific point in the [parser loop](https://github.com/jenstornell/kirby-html-minifier/blob/master/tiny-html-minifier/tiny-html-minifier.php#L45).

Under the hood it makes use of `Kirby\Component\Response` which builds and returns the response by various inputs. I don't know exactly why – but somehow the component seems to handle JS and CSS responses individually.

I think your plugin should exclude such types as it will **cause some unexpected behaviours**:

### JavaScript
It will break and throw an exception if a custom JS file contains some simple comparsions.

##### Input
```js
const a = 1 < 3;
```

##### Output
```js
<const a = 1 < 3;
```

Which will throw (obviously) an exception: `Uncaught SyntaxError: Unexpected token <`

### CSS
It will break without any errors but if you have a css rule like that you could get some wired layout issues.

##### Input
```css
.error-message {
    color:red;
}

.sign-in-button {
    content: "<";
}
```

##### Output
```css
<.error-message {
    color:red;
}

.sign-in-button {
    content: "<";
}
```